### PR TITLE
ユーザー指定の修正

### DIFF
--- a/src/model/command.rs
+++ b/src/model/command.rs
@@ -82,6 +82,7 @@ peg::parser! {
 
     rule user() -> UserId
       = "<@!" n:$(['0'..='9']+) ">" { UserId(n.parse().unwrap()) }
+      / "<@" n:$(['0'..='9']+) ">" { UserId(n.parse().unwrap()) }
 
     rule users() -> Vec<UserId>
       = l:user() ** _ {? if l.is_empty() { Err("non-empty list of users") } else { Ok(l) } }

--- a/src/model/command.rs
+++ b/src/model/command.rs
@@ -401,8 +401,20 @@ mod tests {
     fn test_kaisanee_en() {
         assert_eq!(parser::kaisanee("All"), Ok(KaisaneeSpecifier::All));
         assert_eq!(parser::kaisanee("me"), Ok(KaisaneeSpecifier::Me));
+    }
+
+    #[test]
+    fn test_kaisanee_users() {
         assert_eq!(
             parser::kaisanee("<@!12345> <@!45678><@!99999>"),
+            Ok(KaisaneeSpecifier::Users(vec![
+                UserId(12345),
+                UserId(45678),
+                UserId(99999)
+            ]))
+        );
+        assert_eq!(
+            parser::kaisanee("<@12345><@45678><@99999>"),
             Ok(KaisaneeSpecifier::Users(vec![
                 UserId(12345),
                 UserId(45678),


### PR DESCRIPTION
対象としてユーザーをメンションして指定する際に、 Discord がメッセージでメンションする際のフォーマットが以前は `<@!USER_ID>` だったのが現在は `<@USER_ID>` が使われるようになった影響で正しくパースされていなかったのを修正します。

ドキュメントによると `<@!USER_ID>` 形式は非推奨であるが同じように処理されるべきと書かれているので、処理できるように残してあります。

> User mentions with an exclamation mark are deprecated and should be handled like any other user mention.
https://discord.com/developers/docs/reference#message-formatting